### PR TITLE
Fix typo in matrixlib.py by replacing listSubrange call with sequenceSubrange call 

### DIFF
--- a/libraries/matrixlib.py
+++ b/libraries/matrixlib.py
@@ -83,7 +83,7 @@ class MatrixLib :
       result = []
       prod: int = ocl.prd(ocl.tail(sh))
       for i in range(sh[0]):
-        rowi: list = MatrixLib.fillMatrixForm(ocl.listSubrange(sq, prod * (i - 1), (prod * i) - 1), ocl.tail(sh))
+        rowi: list = MatrixLib.fillMatrixForm(ocl.sequenceSubrange(sq, 1 + prod * (i - 1), (prod * i)), ocl.tail(sh))
         result.append(rowi)
       return result
 

--- a/libraries/ocl.js
+++ b/libraries/ocl.js
@@ -1178,7 +1178,7 @@ def values(m) :
 # print(pp)
 
 # ss = [1, 4, 6, 7, 2]
-# print(listSubrange(ss, 2, -1))
+# print(sequenceSubrange(ss, 2, -1))
 
 # mp = dict({"a": 1, "b": 2})
 

--- a/libraries/ocl.py
+++ b/libraries/ocl.py
@@ -1193,7 +1193,7 @@ def values(m) :
 # print(pp)
 
 # ss = [1, 4, 6, 7, 2]
-# print(listSubrange(ss, 2, -1))
+# print(sequenceSubrange(ss, 2, -1))
 
 # mp = dict({"a": 1, "b": 2})
 

--- a/libraries/ocljs.txt
+++ b/libraries/ocljs.txt
@@ -1259,7 +1259,7 @@ def values(m) :
 # print(pp)
 
 # ss = [1, 4, 6, 7, 2]
-# print(listSubrange(ss, 2, -1))
+# print(sequenceSubrange(ss, 2, -1))
 
 # mp = dict({"a": 1, "b": 2})
 


### PR DESCRIPTION
Also replace all other erroneous `listSubrange` calls in commented out lines of code.