### PR TITLE
Fix all syntax errors in OCLC++.h and OCLC++11.h

### DIFF
--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <ctime>
 #include <cmath>
+#include <iosfwd>
 
 using namespace std;
 

--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -7,6 +7,8 @@
 
 #include <set>
 #include <vector>
+#include <string>
+#include <map>
 
 using namespace std;
 

--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -5,6 +5,9 @@
 #undef max
 #undef min
 
+#include <set>
+#include <vector>
+
 using namespace std;
 
 class Runnable

--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <ctime>
+#include <cmath>
 
 using namespace std;
 

--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -43,7 +43,7 @@ public:
       return ((int) y)/pow(10,n);
     }
 
-    static bool isIn(_T x, std::set<_T>* st)
+    static bool isIn(_T x, set<_T>* st)
     {
         return (st->find(x) != st->end());
     }
@@ -53,7 +53,7 @@ public:
         return (find(sq->begin(), sq->end(), x) != sq->end());
     }
 
-    static bool isSubset(std::set<_T>* s1, set<_T>* s2)
+    static bool isSubset(set<_T>* s1, set<_T>* s2)
     {
         bool res = true;
         for (auto _pos = s1->begin(); _pos != s1->end(); ++_pos)
@@ -64,7 +64,7 @@ public:
         return res;
     }
 
-    static bool isSubset(std::set<_T>* s1, vector<_T>* s2)
+    static bool isSubset(set<_T>* s1, vector<_T>* s2)
     {
         bool res = true;
         for (auto _pos = s1->begin(); _pos != s1->end(); ++_pos)
@@ -75,7 +75,7 @@ public:
         return res;
     }
 
-    static bool isSubset(std::vector<_T>* s1, vector<_T>* s2)
+    static bool isSubset(vector<_T>* s1, vector<_T>* s2)
     {
         bool res = true;
         for (auto _pos = s1->begin(); _pos != s1->end(); ++_pos)
@@ -86,7 +86,7 @@ public:
         return res;
     }
 
-    static bool isSubset(std::vector<_T>* s1, set<_T>* s2)
+    static bool isSubset(vector<_T>* s1, set<_T>* s2)
     {
         bool res = true;
         for (auto _pos = s1->begin(); _pos != s1->end(); ++_pos)
@@ -97,9 +97,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* makeSet(_T x)
+    static set<_T>* makeSet(_T x)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         res->insert(x);
         return res;
     }
@@ -111,7 +111,7 @@ public:
         return res;
     }
 
-    static std::set<_T>* addSet(std::set<_T>* s, _T x)
+    static set<_T>* addSet(set<_T>* s, _T x)
     {
         s->insert(x);
         return s;
@@ -129,7 +129,7 @@ public:
         return s;
     }
 
-    static vector<_T>* asSequence(std::set<_T>* c)
+    static vector<_T>* asSequence(set<_T>* c)
     {
         vector<_T>* res = new vector<_T>();
         for (auto _pos = c->begin(); _pos != c->end(); ++_pos)
@@ -139,7 +139,7 @@ public:
         return res;
     }
 
-    static vector<_T>* asSequence(std::vector<_T>* c)
+    static vector<_T>* asSequence(vector<_T>* c)
     {
         return c;
     }
@@ -215,7 +215,7 @@ public:
         return buff.str();
     }
 
-    static string collectionToString(std::set<_T>* c)
+    static string collectionToString(set<_T>* c)
     {
         ostringstream buff;
         buff << "Set{";
@@ -276,55 +276,55 @@ public:
 
 
 
-    static _T max(std::set<_T>* l)
+    static _T max(set<_T>* l)
     {
-        return *std::max_element(l->begin(), l->end());
+        return *max_element(l->begin(), l->end());
     }
 
     static _T max(vector<_T>* l)
     {
-        return *std::max_element(l->begin(), l->end());
+        return *max_element(l->begin(), l->end());
     }
 
 
-    static _T min(std::set<_T>* l)
+    static _T min(set<_T>* l)
     {
-        return *std::min_element(l->begin(), l->end());
+        return *min_element(l->begin(), l->end());
     }
 
     static _T min(vector<_T>* l)
     {
-        return *std::min_element(l->begin(), l->end());
+        return *min_element(l->begin(), l->end());
     }
 
 
-    static std::set<_T>* unionSet(std::set<_T>* a, std::set<_T>* b)
+    static set<_T>* unionSet(set<_T>* a, set<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         res->insert(a->begin(), a->end());
         res->insert(b->begin(), b->end());
         return res;
     }
 
-    static std::set<_T>* unionSet(vector<_T>* a, std::set<_T>* b)
+    static set<_T>* unionSet(vector<_T>* a, set<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         res->insert(a->begin(), a->end());
         res->insert(b->begin(), b->end());
         return res;
     }
 
-    static std::set<_T>* unionSet(std::set<_T>* a, vector<_T>* b)
+    static set<_T>* unionSet(set<_T>* a, vector<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         res->insert(a->begin(), a->end());
         res->insert(b->begin(), b->end());
         return res;
     }
 
-    static std::set<_T>* unionSet(std::vector<_T>* a, vector<_T>* b)
+    static set<_T>* unionSet(vector<_T>* a, vector<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         res->insert(a->begin(), a->end());
         res->insert(b->begin(), b->end());
         return res;
@@ -343,7 +343,7 @@ public:
         return res;
     }
 
-    static vector<_T>* subtract(vector<_T>* a, std::set<_T>* b)
+    static vector<_T>* subtract(vector<_T>* a, set<_T>* b)
     {
         vector<_T>* res = new vector<_T>();
         for (int i = 0; i < a->size(); i++)
@@ -357,9 +357,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* subtract(std::set<_T>* a, std::set<_T>* b)
+    static set<_T>* subtract(set<_T>* a, set<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (auto _pos = a->begin(); _pos != a->end(); ++_pos)
         {
             if (UmlRsdsLib<_T>::isIn(*_pos, b)) {}
@@ -371,9 +371,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* subtract(std::set<_T>* a, vector<_T>* b)
+    static set<_T>* subtract(set<_T>* a, vector<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (auto _pos = a->begin(); _pos != a->end(); ++_pos)
         {
             if (UmlRsdsLib<_T>::isIn(*_pos, b)) {}
@@ -398,9 +398,9 @@ public:
 
 
 
-    static std::set<_T>* intersection(std::set<_T>* a, std::set<_T>* b)
+    static set<_T>* intersection(set<_T>* a, set<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (auto _pos = a->begin(); _pos != a->end(); ++_pos)
         {
             if (UmlRsdsLib<_T>::isIn(*_pos, b))
@@ -411,9 +411,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* intersection(std::set<_T>* a, vector<_T>* b)
+    static set<_T>* intersection(set<_T>* a, vector<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (auto _pos = a->begin(); _pos != a->end(); ++_pos)
         {
             if (UmlRsdsLib<_T>::isIn(*_pos, b))
@@ -424,7 +424,7 @@ public:
         return res;
     }
 
-    static vector<_T>* intersection(vector<_T>* a, std::set<_T>* b)
+    static vector<_T>* intersection(vector<_T>* a, set<_T>* b)
     {
         vector<_T>* res = new vector<_T>();
         for (int i = 0; i < a->size(); i++)
@@ -452,9 +452,9 @@ public:
 
 
 
-    static std::set<_T>* symmetricDifference(vector<_T>* a, vector<_T>* b)
+    static set<_T>* symmetricDifference(vector<_T>* a, vector<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (int i = 0; i < a->size(); i++)
         {
             if (UmlRsdsLib<_T>::isIn((*a)[i], b)) {}
@@ -468,9 +468,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* symmetricDifference(std::set<_T>* a, vector<_T>* b)
+    static set<_T>* symmetricDifference(set<_T>* a, vector<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (auto _pos = a->begin(); _pos != a->end(); _pos++)
         {
             if (UmlRsdsLib<_T>::isIn(*_pos, b)) {}
@@ -484,9 +484,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* symmetricDifference(vector<_T>* a, std::set<_T>* b)
+    static set<_T>* symmetricDifference(vector<_T>* a, set<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (int i = 0; i < a->size(); i++)
         {
             if (UmlRsdsLib<_T>::isIn((*a)[i], b)) {}
@@ -500,9 +500,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* symmetricDifference(std::set<_T>* a, std::set<_T>* b)
+    static set<_T>* symmetricDifference(set<_T>* a, set<_T>* b)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         for (auto _pos = a->begin(); _pos != a->end(); _pos++)
         {
             if (UmlRsdsLib<_T>::isIn(*_pos, b)) {}
@@ -520,7 +520,7 @@ public:
 
     static bool isUnique(vector<_T>* evals)
     {
-        std::set<_T> vals;
+        set<_T> vals;
         for (int i = 0; i < evals->size(); i++)
         {
             _T ob = (*evals)[i];
@@ -530,7 +530,7 @@ public:
         return true;
     }
 
-    static bool isUnique(std::set<_T>* evals)
+    static bool isUnique(set<_T>* evals)
     {
         return true;
     }
@@ -587,10 +587,10 @@ public:
         return _sum;
     }
 
-    static string sumString(std::set<string>* a)
+    static string sumString(set<string>* a)
     {
         string _sum("");
-        std::set<string>::iterator _pos;
+        set<string>::iterator _pos;
         for (_pos = a->begin(); _pos != a->end(); ++_pos)
         {
             _sum.append(*_pos);
@@ -608,7 +608,7 @@ public:
         return _sum;
     }
 
-    static _T sum(std::set<_T>* a)
+    static _T sum(set<_T>* a)
     {
         _T _sum(0);
         for (auto _pos = a->begin(); _pos != a->end(); ++_pos)
@@ -630,7 +630,7 @@ public:
         return _prd;
     }
 
-    static _T prd(std::set<_T>* a)
+    static _T prd(set<_T>* a)
     {
         _T _prd(1);
         for (auto _pos = a->begin(); _pos != a->end(); ++_pos)
@@ -650,7 +650,7 @@ public:
         return res;
     }
 
-    static vector<_T>* concatenate(vector<_T>* a, std::set<_T>* b)
+    static vector<_T>* concatenate(vector<_T>* a, set<_T>* b)
     {
         vector<_T>* res = new vector<_T>();
         res->insert(res->end(), a->begin(), a->end());
@@ -661,14 +661,14 @@ public:
 
 
 
-    static std::set<_T>* asSet(vector<_T>* c)
+    static set<_T>* asSet(vector<_T>* c)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         res->insert(c->begin(), c->end());
         return res;
     }
 
-    static std::set<_T>* asSet(std::set<_T>* c)
+    static set<_T>* asSet(set<_T>* c)
     {
         return c;
     }
@@ -704,7 +704,7 @@ public:
         {
             res->push_back(*_pos);
         }
-        std::random_shuffle(res->begin(), res->end());
+        random_shuffle(res->begin(), res->end());
         return res;
     }
 
@@ -714,7 +714,7 @@ public:
     {
         vector<_T>* res = new vector<_T>();
         res->insert(res->end(), a->begin(), a->end());
-        std::reverse(res->begin(), res->end());
+        reverse(res->begin(), res->end());
         return res;
     }
 
@@ -740,9 +740,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* front(std::set<_T>* a)
+    static set<_T>* front(set<_T>* a)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (a->size() == 0) { return res; }
         auto _pos = a->end();
         _pos--;
@@ -760,9 +760,9 @@ public:
         return res;
     }
 
-  static std::set<_T>* tail(std::set<_T>* a)
+  static set<_T>* tail(set<_T>* a)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (a->size() == 0) { return res; }
         auto _pos = a->begin();
         _pos++;
@@ -774,32 +774,32 @@ public:
     {
         vector<_T>* res = new vector<_T>();
         res->insert(res->end(), a->begin(), a->end());
-        std::sort(res->begin(), res->end());
+        sort(res->begin(), res->end());
         return res;
     }
 
-    static vector<_T>* sort(std::set<_T>* a)
+    static vector<_T>* sort(set<_T>* a)
     {
         vector<_T>* res = new vector<_T>();
         res->insert(res->end(), a->begin(), a->end());
-        std::sort(res->begin(), res->end());
+        sort(res->begin(), res->end());
         return res;
     }
 
 
-    static vector<_T>* sort(vector<_T>* a, std::function<bool(_T,_T)> f)
+    static vector<_T>* sort(vector<_T>* a, function<bool(_T,_T)> f)
     {
         vector<_T>* res = new vector<_T>();
         res->insert(res->end(), a->begin(), a->end());
-        std::sort(res->begin(), res->end(), f);
+        sort(res->begin(), res->end(), f);
         return res;
     }
 
-    static vector<_T>* sort(std::set<_T>* a, std::function<bool(_T, _T)> f)
+    static vector<_T>* sort(set<_T>* a, function<bool(_T, _T)> f)
     {
         vector<_T>* res = new vector<_T>();
         res->insert(res->end(), a->begin(), a->end());
-        std::sort(res->begin(), res->end(), f);
+        sort(res->begin(), res->end(), f);
         return res;
     }
 
@@ -848,7 +848,7 @@ public:
     }
 
 
-    static int count(std::set<_T>* l, _T obj)
+    static int count(set<_T>* l, _T obj)
     {
         if (l->find(obj) != l->end()) { return 1; }
         else { return 0; }
@@ -856,7 +856,7 @@ public:
 
     static int count(vector<_T>* l, _T obj)
     {
-        return std::count(l->begin(), l->end(), obj);
+        return count(l->begin(), l->end(), obj);
     }
 
     static int count(string s, string x)
@@ -897,7 +897,7 @@ public:
         return v->at(0);
     }
 
-    static _T any(std::set<_T>* v)
+    static _T any(set<_T>* v)
     {
         if (v->size() == 0) { return 0; }
         auto _pos = v->begin();
@@ -912,7 +912,7 @@ public:
         return v->at(0);
     }
 
-    static _T first(std::set<_T>* v)
+    static _T first(set<_T>* v)
     {
         if (v->size() == 0) { return 0; }
         auto _pos = v->begin();
@@ -927,7 +927,7 @@ public:
         return v->at(v->size() - 1);
     }
 
-    static _T last(std::set<_T>* v)
+    static _T last(set<_T>* v)
     {
         if (v->size() == 0) { return 0; }
         auto _pos = v->end();
@@ -1131,12 +1131,12 @@ public:
     }
 
 
-    static std::set<_T>* intersectAll(std::set<std::set<_T>*>* se)
+    static set<_T>* intersectAll(set<set<_T>*>* se)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (se->size() == 0) { return res; }
         auto _pos = se->begin();
-        std::set<_T>* frst = *_pos;
+        set<_T>* frst = *_pos;
         res->insert(frst->begin(), frst->end());
         ++_pos;
         for (; _pos != se->end(); ++_pos)
@@ -1146,9 +1146,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* intersectAll(std::set<vector<_T>*>* se)
+    static set<_T>* intersectAll(set<vector<_T>*>* se)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (se->size() == 0) { return res; }
         auto _pos = se->begin();
         vector<_T>* frst = *_pos;
@@ -1161,11 +1161,11 @@ public:
         return res;
     }
 
-    static std::set<_T>* intersectAll(vector<std::set<_T>*>* se)
+    static set<_T>* intersectAll(vector<set<_T>*>* se)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (se->size() == 0) { return res; }
-        std::set<_T>* frst = (*se)[0];
+        set<_T>* frst = (*se)[0];
         res->insert(frst->begin(), frst->end());
         for (int i = 1; i < se->size(); ++i)
         {
@@ -1189,9 +1189,9 @@ public:
 
 
 
-    static std::set<_T>* unionAll(std::set<set<_T>*>* se)
+    static set<_T>* unionAll(set<set<_T>*>* se)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (se->size() == 0) { return res; }
         
         for (auto _pos = se->begin(); _pos != se->end(); ++_pos)
@@ -1201,9 +1201,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* unionAll(std::set<vector<_T>*>* se)
+    static set<_T>* unionAll(set<vector<_T>*>* se)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (se->size() == 0) { return res; }
         for (auto _pos = se->begin(); _pos != se->end(); ++_pos)
         {
@@ -1212,9 +1212,9 @@ public:
         return res;
     }
 
-    static std::set<_T>* unionAll(vector<set<_T>*>* se)
+    static set<_T>* unionAll(vector<set<_T>*>* se)
     {
-        std::set<_T>* res = new std::set<_T>();
+        set<_T>* res = new set<_T>();
         if (se->size() == 0) { return res; }
         for (int i = 0; i < se->size(); ++i)
         {
@@ -1224,8 +1224,8 @@ public:
     }
 
 
-  static std::map<string,_T>* unionAllMap(vector<map<string,_T>*>* se)
-    { std::map<string,_T>* res = new std::map<string,_T>();
+  static map<string,_T>* unionAllMap(vector<map<string,_T>*>* se)
+    { map<string,_T>* res = new map<string,_T>();
       if (se->size() == 0) { return res; }
       for (int i = 0; i < se->size(); ++i)
       { res = UmlRsdsLib<_T>::unionMap(res, (*se)[i]); }
@@ -1500,14 +1500,14 @@ public:
 
     static bool isInteger(string str)
     {
-        try { std::stoi(str); return true; }
+        try { stoi(str); return true; }
         catch (exception _e) { return false; }
     }
 
 
     static bool isReal(string str)
     {
-        try { std::stod(str); return true; }
+        try { stod(str); return true; }
         catch (exception _e)
         {
             return false;
@@ -1533,7 +1533,7 @@ public:
         if (str[0] == '0' && str.length() > 1 && str[1] == 'x')
         {
             try {
-                int x = std::stoi(str, 0, 16);
+                int x = stoi(str, 0, 16);
                 return x;
             }
             catch (exception e) { return 0; }
@@ -1541,7 +1541,7 @@ public:
         else if (str[0] == '0' && str.length() > 1)
         {
             try {
-                int y = std::stoi(str, 0, 8);
+                int y = stoi(str, 0, 8);
                 return y;
             }
             catch (exception f)
@@ -1550,7 +1550,7 @@ public:
             }
         }
         try {
-            int z = std::stoi(str, 0, 10);
+            int z = stoi(str, 0, 10);
             return z;
         }
         catch (exception g) { return 0; }
@@ -1567,7 +1567,7 @@ public:
         if (str[0] == '0' && str.length() > 1 && str[1] == 'x')
         {
             try {
-                long x = std::stol(str, 0, 16);
+                long x = stol(str, 0, 16);
                 return x;
             }
             catch (exception e) { return 0; }
@@ -1575,7 +1575,7 @@ public:
         else if (str[0] == '0' && str.length() > 1)
         {
             try {
-                long y = std::stol(str, 0, 8);
+                long y = stol(str, 0, 8);
                 return y;
             }
             catch (exception f)
@@ -1584,7 +1584,7 @@ public:
             }
         }
         try {
-            long z = std::stol(str, 0, 10);
+            long z = stol(str, 0, 10);
             return z;
         }
         catch (exception g) { return 0; }
@@ -1599,7 +1599,7 @@ public:
         }
 
         try {
-            double x = std::stod(str);
+            double x = stod(str);
             return x;
         }
         catch (exception e) { return 0.0; }
@@ -1609,7 +1609,7 @@ public:
 
     static bool isLong(string str)
     {
-        try { std::stol(str); return true; }
+        try { stol(str); return true; }
         catch (exception _e) { return false; }
     }
 
@@ -1632,16 +1632,16 @@ public:
 
     static bool hasMatch(string str, string patt)
     {
-        std::regex rr(patt);
-        return std::regex_search(str, rr);
+        regex rr(patt);
+        return regex_search(str, rr);
     }
 
 
 
     static bool isMatch(string str, string patt)
     {
-        std::regex rr(patt);
-        return std::regex_match(str, rr);
+        regex rr(patt);
+        return regex_match(str, rr);
     }
 
 
@@ -1654,14 +1654,14 @@ public:
         {
             return res;
         }
-        std::regex patt_regex(patt);
-        auto words_begin = std::sregex_iterator(s.begin(), s.end(), patt_regex);
-        auto words_end = std::sregex_iterator();
+        regex patt_regex(patt);
+        auto words_begin = sregex_iterator(s.begin(), s.end(), patt_regex);
+        auto words_end = sregex_iterator();
 
-        for (std::sregex_iterator i = words_begin; i != words_end; ++i)
+        for (sregex_iterator i = words_begin; i != words_end; ++i)
         {
-            std::smatch match = *i;
-            std::string match_str = match.str();
+            smatch match = *i;
+            string match_str = match.str();
             if (match_str.length() > 0)
             {
                 res->push_back(match_str);
@@ -1679,14 +1679,14 @@ public:
         {
             return res;
         }
-        std::regex patt_regex(patt);
-        auto words_begin = std::sregex_iterator(s.begin(), s.end(), patt_regex);
-        auto words_end = std::sregex_iterator();
+        regex patt_regex(patt);
+        auto words_begin = sregex_iterator(s.begin(), s.end(), patt_regex);
+        auto words_end = sregex_iterator();
 
-        for (std::sregex_iterator i = words_begin; i != words_end; ++i)
+        for (sregex_iterator i = words_begin; i != words_end; ++i)
         {
-            std::smatch match = *i;
-            std::string match_str = match.str();
+            smatch match = *i;
+            string match_str = match.str();
             if (match_str.length() > 0)
             {
                 return match_str;
@@ -1698,18 +1698,18 @@ public:
 
     static string replaceAll(string text, string patt, string rep)
     {
-        std::regex patt_re(patt);
-        std::string res = std::regex_replace(text, patt_re, rep);
+        regex patt_re(patt);
+        string res = regex_replace(text, patt_re, rep);
         return res;
     }
 
 
     static string replaceFirstMatch(string text, string patt, string rep)
     {
-        std::regex patt_re(patt);
-        std::regex_constants::match_flag_type fonly =
-            std::regex_constants::format_first_only;
-        std::string res = std::regex_replace(text, patt_re, rep, fonly);
+        regex patt_re(patt);
+        regex_constants::match_flag_type fonly =
+            regex_constants::format_first_only;
+        string res = regex_replace(text, patt_re, rep, fonly);
         return res;
     }
 
@@ -1723,13 +1723,13 @@ public:
             res->push_back(s);
             return res;
         }
-        std::regex patt_regex(patt);
-        auto words_begin = std::sregex_iterator(s.begin(), s.end(), patt_regex);
-        auto words_end = std::sregex_iterator();
+        regex patt_regex(patt);
+        auto words_begin = sregex_iterator(s.begin(), s.end(), patt_regex);
+        auto words_end = sregex_iterator();
         int prev = 0;
-        for (std::sregex_iterator i = words_begin; i != words_end; ++i)
+        for (sregex_iterator i = words_begin; i != words_end; ++i)
         {
-            std::smatch match = *i;
+            smatch match = *i;
             int pos = match.position(0);
             int ln = match.length(0);
             if (ln > 0)
@@ -1931,8 +1931,8 @@ public:
         return res;
     }
 
-  static std::map<string, _T>* intersectAllMap(vector<map<string, _T>*>* se)
-  { std::map<string, _T>* res = new std::map<string, _T>();
+  static map<string, _T>* intersectAllMap(vector<map<string, _T>*>* se)
+  { map<string, _T>* res = new map<string, _T>();
     if (se->size() == 0) { return res; }
     res = (*se)[0]; 
     for (int i = 1; i < se->size(); ++i)
@@ -1941,9 +1941,9 @@ public:
   }
 
 
-    static std::set<string>* keys(map<string, _T>* s)
+    static set<string>* keys(map<string, _T>* s)
     {
-        std::set<string>* res = new std::set<string>();
+        set<string>* res = new set<string>();
 
         for (auto iter = s->begin(); iter != s->end(); ++iter)
         {
@@ -1967,7 +1967,7 @@ public:
     }
 
 
-    static map<string, _T>* restrict(map<string, _T>* m1, std::set<string>* ks)
+    static map<string, _T>* restrict(map<string, _T>* m1, set<string>* ks)
     { map<string, _T>* res = new map<string, _T>();
       for (auto iter = m1->begin(); iter != m1->end(); ++iter)
       {
@@ -1980,7 +1980,7 @@ public:
       return res;
     }
 
-    static map<string, _T>* antirestrict(map<string, _T>* m1, std::set<string>* ks)
+    static map<string, _T>* antirestrict(map<string, _T>* m1, set<string>* ks)
     {
         map<string, _T>* res = new map<string, _T>();
         for (auto iter = m1->begin(); iter != m1->end(); ++iter)
@@ -2001,7 +2001,7 @@ template<class S, class T, class R>
 class UmlRsdsOcl {
 public:
 
-    static T iterate(vector<S>* _s, T initialValue, std::function<T(S, T)> _f)
+    static T iterate(vector<S>* _s, T initialValue, function<T(S, T)> _f)
     {
         T acc = initialValue;
         for (auto _pos = _s->begin(); _pos != _s->end(); ++_pos)
@@ -2161,9 +2161,9 @@ public:
         return res;
     }
 
-    static std::set<S>* keys(map<S, T>* s)
+    static set<S>* keys(map<S, T>* s)
     {
-        std::set<S>* res = new std::set<S>();
+        set<S>* res = new set<S>();
 
         for (auto iter = s->begin(); iter != s->end(); ++iter)
         {
@@ -2187,7 +2187,7 @@ public:
     }
 
 
-    static map<S, T>* restrict(map<S, T>* m1, std::set<S>* ks)
+    static map<S, T>* restrict(map<S, T>* m1, set<S>* ks)
     { map<S, T>* res = new map<S, T>();
       for (auto iter = m1->begin(); iter != m1->end(); ++iter)
       {
@@ -2200,7 +2200,7 @@ public:
       return res;
     }
 
-    static map<S, T>* antirestrict(map<S, T>* m1, std::set<S>* ks)
+    static map<S, T>* antirestrict(map<S, T>* m1, set<S>* ks)
     {
         map<S, T>* res = new map<S, T>();
         for (auto iter = m1->begin(); iter != m1->end(); ++iter)
@@ -2214,7 +2214,7 @@ public:
         return res;
     }
 
-    static map<S, T>* selectMap(map<S, T>* m1, std::function<bool(T)> f)
+    static map<S, T>* selectMap(map<S, T>* m1, function<bool(T)> f)
     {
         map<S, T>* res = new map<S, T>();
         for (auto iter = m1->begin(); iter != m1->end(); ++iter)
@@ -2229,7 +2229,7 @@ public:
         return res;
     }
 
-    static map<S, T>* rejectMap(map<S, T>* m1, std::function<bool(T)> f)
+    static map<S, T>* rejectMap(map<S, T>* m1, function<bool(T)> f)
     {
         map<S, T>* res = new map<S, T>();
         for (auto iter = m1->begin(); iter != m1->end(); ++iter)
@@ -2245,7 +2245,7 @@ public:
         return res;
     }
 
-    static map<S, R>* collectMap(map<S, T>* m1, std::function<R(T)> f)
+    static map<S, R>* collectMap(map<S, T>* m1, function<R(T)> f)
     {
         map<S, R>* res = new map<S, R>();
         for (auto iter = m1->begin(); iter != m1->end(); ++iter)

--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -2668,7 +2668,7 @@ public:
         return ex;
     }
 
-    const char* what() const { return message; }
+    const char* what() const throw() { return message; }
 
     string getMessage() { return string(message); }
 
@@ -2704,7 +2704,7 @@ public:
         return ex;
     }
 
-    const char* what() const { return message; }
+    const char* what() const throw() { return message; }
 
     string getMessage() { return string(message); }
 
@@ -2740,7 +2740,7 @@ public:
         return ex;
     }
 
-    const char* what() const { return message; }
+    const char* what() const throw() { return message; }
 
     string getMessage() { return string(message); }
 
@@ -2776,7 +2776,7 @@ public:
         return ex;
     }
 
-    const char* what() const { return message; }
+    const char* what() const throw() { return message; }
 
     string getMessage() { return string(message); }
 

--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <ctime>
 #include <cmath>
+#include <iostream>
 #include <iosfwd>
 
 using namespace std;

--- a/libraries/OCLC++.h
+++ b/libraries/OCLC++.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <iostream>
 #include <iosfwd>
+#include <regex>
 
 using namespace std;
 

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <ctime>
 #include <cmath>
+#include <iosfwd>
 
 using namespace std;
 

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -5,6 +5,8 @@
 
 #include <set>
 #include <vector>
+#include <string>
+#include <map>
 
 using namespace std;
 

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -42,7 +42,7 @@ public:
 
     static bool isSubset(set<_T>* s1, set<_T>* s2)
     { bool res = true; 
-      for (set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (typename set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { } 
         else { return false; } 
       }
@@ -51,7 +51,7 @@ public:
 
     static bool isSubset(set<_T>* s1, vector<_T>* s2)
     { bool res = true; 
-      for (set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (typename set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { }
         else { return false; } 
       }
@@ -60,7 +60,7 @@ public:
 
     static bool isSubset(vector<_T>* s1, vector<_T>* s2)
     { bool res = true; 
-      for (vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (typename vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { }
         else { return false; } 
       }
@@ -69,7 +69,7 @@ public:
 
     static bool isSubset(vector<_T>* s1, set<_T>* s2)
     { bool res = true; 
-      for (vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (typename vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { }
         else { return false; } 
       }
@@ -104,7 +104,7 @@ public:
 
     static vector<_T>* asSequence(set<_T>* c)
     { vector<_T>* res = new vector<_T>();
-      for (set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
+      for (typename set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
       { res->push_back(*_pos); } 
       return res;
    }
@@ -151,7 +151,7 @@ public:
 
   static map<string,_T>* copyMap(map<string,_T>* m)
   { map<string,_T>* res = new map<string,_T>();
-    map<string,_T>::iterator iter; 
+    typename map<string,_T>::iterator iter; 
     for (iter = m->begin(); iter != m->end(); ++iter)
     { string key = iter->first;
       (*res)[key] = iter->second;  
@@ -162,7 +162,7 @@ public:
   static string collectionToString(vector<_T>* c)
   { ostringstream buff;
     buff << "Sequence{";
-    for (vector<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
+    for (typename vector<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
     { buff << *_pos;
       if (_pos + 1 < c->end())
       { buff << ", "; }
@@ -174,7 +174,7 @@ public:
   static string collectionToString(set<_T>* c)
   { ostringstream buff;
     buff << "Set{"; 
-    for (set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
+    for (typename set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
     { buff << *_pos;
       if (_pos + 1 < c->end())
       { buff << ", "; }
@@ -276,7 +276,7 @@ public:
 
   static set<_T>* subtract(set<_T>* a, set<_T>* b)
   { set<_T>* res = new set<_T>(); 
-    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+    for (typename set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos,b)) { }
       else
       { res->insert(*_pos); }
@@ -286,7 +286,7 @@ public:
 
   static set<_T>* subtract(set<_T>* a, vector<_T>* b)
   { set<_T>* res = new set<_T>(); 
-    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+    for (typename set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos,b)) { }
       else
       { res->insert(*_pos); }
@@ -304,7 +304,7 @@ public:
 
   static set<_T>* intersection(set<_T>* a, set<_T>* b)
   { set<_T>* res = new set<_T>(); 
-    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+    for (typename set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos, b))
       { res->insert(*_pos); }
     }
@@ -313,7 +313,7 @@ public:
 
   static set<_T>* intersection(set<_T>* a, vector<_T>* b)
   { set<_T>* res = new set<_T>(); 
-    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+    for (typename set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos, b))
       { res->insert(*_pos); }
     }
@@ -355,7 +355,7 @@ public:
 
     static set<_T>* symmetricDifference(set<_T>* a, vector<_T>* b)
     { set<_T>* res = new set<_T>();
-      for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
+      for (typename set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, b)) { }
         else { res->insert(*_pos); }
       }
@@ -372,7 +372,7 @@ public:
       { if (UmlRsdsLib<_T>::isIn((*a)[i], b)) { }
         else { res->insert((*a)[i]); }
       }
-      for (set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
+      for (typename set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, a)) { }
         else { res->insert(*_pos); }
       }
@@ -381,11 +381,11 @@ public:
 
     static set<_T>* symmetricDifference(set<_T>* a, set<_T>* b)
     { set<_T>* res = new set<_T>();
-      for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
+      for (typename set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, b)) { }
         else { res->insert(*_pos); }
       }
-      for (set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
+      for (typename set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, a)) { }
         else { res->insert(*_pos); }
       }
@@ -459,7 +459,7 @@ public:
 
   static _T sum(set<_T>* a)
   { _T _sum(0); 
-    set<_T>::iterator _pos;
+    typename set<_T>::iterator _pos;
     for (_pos = a->begin(); _pos != a->end(); ++_pos)
     { _sum += *_pos; }
     return _sum; }
@@ -474,7 +474,7 @@ public:
 
   static _T prd(set<_T>* a)
   { _T _prd(1); 
-    set<_T>::iterator _pos;
+    typename set<_T>::iterator _pos;
     for (_pos = a->begin(); _pos != a->end(); ++_pos)
     { _prd *= *_pos; }
     return _prd; }
@@ -509,7 +509,7 @@ public:
 
     static vector<_T>* asOrderedSet(vector<_T>* c)
     { vector<_T>* res = new vector<_T>();
-      for (vector<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
+      for (typename vector<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
       { if (isIn(*_pos, res)) { }
         else 
         { res->push_back(*_pos); }
@@ -519,14 +519,14 @@ public:
 
     static vector<_T>* asOrderedSet(set<_T>* c)
     { vector<_T>* res = new vector<_T>();
-      for (set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
+      for (typename set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
       { res->push_back(*_pos); }
       return res;
     }
 
     static vector<_T>* randomiseSequence(vector<_T>* sq)
     { vector<_T>* res = new vector<_T>();
-      for (vector<_T>::iterator _pos = sq->begin(); _pos != sq->end(); ++_pos)
+      for (typename vector<_T>::iterator _pos = sq->begin(); _pos != sq->end(); ++_pos)
       { res->push_back(*_pos); }
       random_shuffle(res->begin(), res->end());
       return res; 
@@ -551,7 +551,7 @@ public:
   static vector<_T>* front(vector<_T>* a)
   { vector<_T>* res = new vector<_T>(); 
     if (a->size() == 0) { return res; } 
-    vector<_T>::iterator _pos = a->end(); 
+    typename vector<_T>::iterator _pos = a->end(); 
     _pos--; 
     res->insert(res->end(), a->begin(), _pos); 
     return res; }
@@ -560,7 +560,7 @@ public:
   static vector<_T>* tail(vector<_T>* a)
   { vector<_T>* res = new vector<_T>(); 
     if (a->size() == 0) { return res; } 
-    vector<_T>::iterator _pos = a->begin(); 
+    typename vector<_T>::iterator _pos = a->begin(); 
     _pos++; 
     res->insert(res->end(), _pos, a->end()); 
     return res; }
@@ -661,7 +661,7 @@ public:
 
   static _T any(set<_T>* v)
     { if (v->size() == 0) { return 0; }
-      set<_T>::iterator _pos = v->begin();
+      typename set<_T>::iterator _pos = v->begin();
       return *_pos;
     }
 
@@ -674,7 +674,7 @@ public:
 
   static _T first(set<_T>* v)
     { if (v->size() == 0) { return 0; }
-      set<_T>::iterator _pos = v->begin();
+      typename set<_T>::iterator _pos = v->begin();
       return *_pos;
     }
 
@@ -687,7 +687,7 @@ public:
 
   static _T last(set<_T>* v)
   { if (v->size() == 0) { return 0; }
-    set<_T>::iterator _pos = v->end();
+    typename set<_T>::iterator _pos = v->end();
     _pos--;
     return *_pos;
   }
@@ -851,7 +851,7 @@ public:
   static set<_T>* intersectAll(set<set<_T>*>* se)
   { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    set<set<_T>*>::iterator _pos = se->begin();
+    typename set<set<_T>*>::iterator _pos = se->begin();
     set<_T>* frst = *_pos;
     res->insert(frst->begin(), frst->end());
     ++_pos; 
@@ -863,7 +863,7 @@ public:
   static set<_T>* intersectAll(set<vector<_T>*>* se)
   { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    set<vector<_T>*>::iterator _pos = se->begin();
+    typename set<vector<_T>*>::iterator _pos = se->begin();
     vector<_T>* frst = *_pos;
     res->insert(frst->begin(), frst->end());
     ++_pos; 
@@ -897,7 +897,7 @@ public:
   static set<_T>* unionAll(set<set<_T>*>* se)
   { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    set<set<_T>*>::iterator _pos;
+    typename set<set<_T>*>::iterator _pos;
     for (_pos = se->begin(); _pos != se->end(); ++_pos)
     { res = UmlRsdsLib<_T>::unionSet(res, *_pos); }
     return res;
@@ -906,7 +906,7 @@ public:
   static set<_T>* unionAll(set<vector<_T>*>* se)
   { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    set<vector<_T>*>::iterator _pos;
+    typename set<vector<_T>*>::iterator _pos;
     for (_pos = se->begin(); _pos != se->end(); ++_pos)
     { res = UmlRsdsLib<_T>::unionSet(res, *_pos); }
     return res;
@@ -1354,10 +1354,10 @@ public:
     }
 
   static bool includesAllMap(map<string,_T>* sup, map<string,_T>* sub) 
-  { map<string,_T>::iterator iter; 
+  { typename map<string,_T>::iterator iter; 
     for (iter = sub->begin(); iter != sub->end(); ++iter) 
     { string key = iter->first; 
-      map<string,_T>::iterator f = sup->find(key); 
+      typename map<string,_T>::iterator f = sup->find(key); 
       if (f != sup->end())  
       { if (iter->second == f->second) {} 
         else 
@@ -1371,10 +1371,10 @@ public:
 
 
   static bool excludesAllMap(map<string,_T>*  sup, map<string,_T>* sub) 
-  { map<string,_T>::iterator iter; 
+  { typename map<string,_T>::iterator iter; 
     for (iter = sub->begin(); iter != sub->end(); ++iter) 
     { string key = iter->first; 
-      map<string,_T>::iterator f = sup->find(key); 
+      typename map<string,_T>::iterator f = sup->find(key); 
       if (f != sup->end())  
       { if (iter->second == f->second) 
         { return false; } 
@@ -1386,7 +1386,7 @@ public:
 
    static map<string,_T>* includingMap(map<string,_T>* m, string src, _T trg) 
    { map<string,_T>* copy = new map<string,_T>(); 
-     map<string,_T>::iterator iter; 
+     typename map<string,_T>::iterator iter; 
      for (iter = m->begin(); iter != m->end(); ++iter) 
      { string key = iter->first; 
        (*copy)[key] = iter->second; 
@@ -1398,10 +1398,10 @@ public:
 
    static map<string,_T>* excludeAllMap(map<string,_T>* m1, map<string,_T>* m2) 
    { map<string,_T>* res = new map<string,_T>(); 
-     map<string,_T>::iterator iter; 
+     typename map<string,_T>::iterator iter; 
      for (iter = m1->begin(); iter != m1->end(); ++iter) 
      { string key = iter->first; 
-       map<string,_T>::iterator f = m2->find(key); 
+       typename map<string,_T>::iterator f = m2->find(key); 
        if (f != m2->end())  
        { if (iter->second == f->second)  {  } 
          else  
@@ -1417,7 +1417,7 @@ public:
   static map<string,_T>* excludingMapKey(map<string,_T>* m, string k) 
   { // m - { k |-> m(k) }  
     map<string,_T>* res = new map<string,_T>(); 
-    map<string,_T>::iterator iter; 
+    typename map<string,_T>::iterator iter; 
     for (iter = m->begin(); iter != m->end(); ++iter) 
     { string key = iter->first; 
       if (key == k) {} 
@@ -1431,7 +1431,7 @@ public:
   static map<string,_T>* excludingMapValue(map<string,_T>* m, _T v) 
   { // m - { k |-> v }  
     map<string,_T>* res = new map<string,_T>(); 
-    map<string,_T>::iterator iter; 
+    typename map<string,_T>::iterator iter; 
     for (iter = m->begin(); iter != m->end(); ++iter) 
     { string key = iter->first; 
       if (iter->second == v) {} 
@@ -1444,7 +1444,7 @@ public:
 
   static map<string,_T>* unionMap(map<string,_T>* m1, map<string,_T>* m2)  
   { map<string,_T>* res = new map<string,_T>(); 
-    map<string,_T>::iterator iter; 
+    typename map<string,_T>::iterator iter; 
     for (iter = m1->begin(); iter != m1->end(); ++iter) 
     { string key = iter->first; 
       if (m2->count(key) == 0) 
@@ -1460,7 +1460,7 @@ public:
 
   static map<string,_T>* intersectionMap(map<string,_T>* m1, map<string,_T>* m2) 
   { map<string,_T>* res = new map<string,_T>(); 
-    map<string,_T>::iterator iter; 
+    typename map<string,_T>::iterator iter; 
     for (iter = m1->begin(); iter != m1->end(); ++iter) 
     { string key = iter->first; 
       if (m2->count(key) > 0) 
@@ -1473,7 +1473,7 @@ public:
 
 
   static set<string>* keys(map<string,_T>* s)
-  { map<string,_T>::iterator iter;
+  { typename map<string,_T>::iterator iter;
     set<string>* res = new set<string>();
   
     for (iter = s->begin(); iter != s->end(); ++iter)
@@ -1485,7 +1485,7 @@ public:
 
 
   static vector<_T>* values(map<string,_T>* s)
-  { map<string,_T>::iterator iter;
+  { typename map<string,_T>::iterator iter;
     vector<_T>* res = new vector<_T>();
   
     for (iter = s->begin(); iter != s->end(); ++iter)
@@ -1498,7 +1498,7 @@ public:
 
   static map<string,_T>* restrict(map<string,_T>* m1, set<string>* ks)
   { map<string,_T>* res = new map<string,_T>();
-    map<string,_T>::iterator iter;
+    typename map<string,_T>::iterator iter;
     for (iter = m1->begin(); iter != m1->end(); ++iter)
     { string key = iter->first;
       if (ks->find(key) != ks->end())
@@ -1509,7 +1509,7 @@ public:
 
   static map<string,_T>* antirestrict(map<string,_T>* m1, set<string>* ks)
   { map<string,_T>* res = new map<string,_T>();
-    map<string,_T>::iterator iter;
+    typename map<string,_T>::iterator iter;
     for (iter = m1->begin(); iter != m1->end(); ++iter)
     { string key = iter->first;
       if (ks->find(key) == ks->end())

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <iostream>
 #include <iosfwd>
+#include <regex>
 
 using namespace std;
 

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -24,50 +24,50 @@ public:
     }
 
 
-    static bool isIn(_T x, std::set<_T>* st)
+    static bool isIn(_T x, set<_T>* st)
     { return (st->find(x) != st->end()); }
 
     static bool isIn(_T x, vector<_T>* sq)
     { return (find(sq->begin(), sq->end(), x) != sq->end()); }
 
-    static bool isSubset(std::set<_T>* s1, set<_T>* s2)
+    static bool isSubset(set<_T>* s1, set<_T>* s2)
     { bool res = true; 
-      for (std::set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { } 
         else { return false; } 
       }
       return res;
     }
 
-    static bool isSubset(std::set<_T>* s1, vector<_T>* s2)
+    static bool isSubset(set<_T>* s1, vector<_T>* s2)
     { bool res = true; 
-      for (std::set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (set<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { }
         else { return false; } 
       }
       return res;
     }
 
-    static bool isSubset(std::vector<_T>* s1, vector<_T>* s2)
+    static bool isSubset(vector<_T>* s1, vector<_T>* s2)
     { bool res = true; 
-      for (std::vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { }
         else { return false; } 
       }
       return res;
     }
 
-    static bool isSubset(std::vector<_T>* s1, set<_T>* s2)
+    static bool isSubset(vector<_T>* s1, set<_T>* s2)
     { bool res = true; 
-      for (std::vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
+      for (vector<_T>::iterator _pos = s1->begin(); _pos != s1->end(); ++_pos)
       { if (isIn(*_pos, s2)) { }
         else { return false; } 
       }
       return res;
     }
 
-    static std::set<_T>* makeSet(_T x)
-    { std::set<_T>* res = new std::set<_T>();
+    static set<_T>* makeSet(_T x)
+    { set<_T>* res = new set<_T>();
       res->insert(x);
       return res;
     }
@@ -78,7 +78,7 @@ public:
       return res;
     }
 
-    static std::set<_T>* addSet(std::set<_T>* s, _T x)
+    static set<_T>* addSet(set<_T>* s, _T x)
     { s->insert(x); 
       return s;
     }
@@ -92,14 +92,14 @@ public:
     { s->push_back(x);
       return s; }
 
-    static vector<_T>* asSequence(std::set<_T>* c)
+    static vector<_T>* asSequence(set<_T>* c)
     { vector<_T>* res = new vector<_T>();
-      for (std::set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
+      for (set<_T>::iterator _pos = c->begin(); _pos != c->end(); ++_pos)
       { res->push_back(*_pos); } 
       return res;
    }
 
-    static vector<_T>* asSequence(std::vector<_T>* c)
+    static vector<_T>* asSequence(vector<_T>* c)
     { return c; }
 
 
@@ -203,41 +203,41 @@ public:
 
 
 
-  static _T max(std::set<_T>* l)
-  { return *std::max_element(l->begin(), l->end()); }
+  static _T max(set<_T>* l)
+  { return *max_element(l->begin(), l->end()); }
   static _T max(vector<_T>* l)
-  { return *std::max_element(l->begin(), l->end()); }
+  { return *max_element(l->begin(), l->end()); }
 
 
-  static _T min(std::set<_T>* l)
-  { return *std::min_element(l->begin(), l->end()); }
+  static _T min(set<_T>* l)
+  { return *min_element(l->begin(), l->end()); }
   static _T min(vector<_T>* l)
-  { return *std::min_element(l->begin(), l->end()); }
+  { return *min_element(l->begin(), l->end()); }
 
 
-  static std::set<_T>* unionSet(std::set<_T>* a, std::set<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* unionSet(set<_T>* a, set<_T>* b)
+  { set<_T>* res = new set<_T>(); 
     res->insert(a->begin(),a->end()); 
     res->insert(b->begin(),b->end()); 
     return res;
   }
 
-  static std::set<_T>* unionSet(vector<_T>* a, std::set<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* unionSet(vector<_T>* a, set<_T>* b)
+  { set<_T>* res = new set<_T>(); 
     res->insert(a->begin(),a->end()); 
     res->insert(b->begin(),b->end()); 
     return res;
   }
 
-  static std::set<_T>* unionSet(std::set<_T>* a, vector<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* unionSet(set<_T>* a, vector<_T>* b)
+  { set<_T>* res = new set<_T>(); 
     res->insert(a->begin(),a->end()); 
     res->insert(b->begin(),b->end()); 
     return res;
   }
 
-  static std::set<_T>* unionSet(std::vector<_T>* a, vector<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* unionSet(vector<_T>* a, vector<_T>* b)
+  { set<_T>* res = new set<_T>(); 
     res->insert(a->begin(),a->end()); 
     res->insert(b->begin(),b->end()); 
     return res;
@@ -254,7 +254,7 @@ public:
     return res;
   }
 
-  static vector<_T>* subtract(vector<_T>* a, std::set<_T>* b)
+  static vector<_T>* subtract(vector<_T>* a, set<_T>* b)
   { vector<_T>* res = new vector<_T>(); 
     for (int i = 0; i < a->size(); i++)
     { if (UmlRsdsLib<_T>::isIn((*a)[i],b)) { }
@@ -264,9 +264,9 @@ public:
     return res;
   }
 
-  static std::set<_T>* subtract(std::set<_T>* a, std::set<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
-    for (std::set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+  static set<_T>* subtract(set<_T>* a, set<_T>* b)
+  { set<_T>* res = new set<_T>(); 
+    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos,b)) { }
       else
       { res->insert(*_pos); }
@@ -274,9 +274,9 @@ public:
     return res;
   }
 
-  static std::set<_T>* subtract(std::set<_T>* a, vector<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
-    for (std::set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+  static set<_T>* subtract(set<_T>* a, vector<_T>* b)
+  { set<_T>* res = new set<_T>(); 
+    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos,b)) { }
       else
       { res->insert(*_pos); }
@@ -292,25 +292,25 @@ public:
 
 
 
-  static std::set<_T>* intersection(std::set<_T>* a, std::set<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
-    for (std::set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+  static set<_T>* intersection(set<_T>* a, set<_T>* b)
+  { set<_T>* res = new set<_T>(); 
+    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos, b))
       { res->insert(*_pos); }
     }
     return res;
   }
 
-  static std::set<_T>* intersection(std::set<_T>* a, vector<_T>* b)
-  { std::set<_T>* res = new std::set<_T>(); 
-    for (std::set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
+  static set<_T>* intersection(set<_T>* a, vector<_T>* b)
+  { set<_T>* res = new set<_T>(); 
+    for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); ++_pos)
     { if (UmlRsdsLib<_T>::isIn(*_pos, b))
       { res->insert(*_pos); }
     }
     return res;
   }
 
-  static vector<_T>* intersection(vector<_T>* a, std::set<_T>* b)
+  static vector<_T>* intersection(vector<_T>* a, set<_T>* b)
   { vector<_T>* res = new vector<_T>(); 
     for (int i = 0; i < a->size(); i++)
     { if (UmlRsdsLib<_T>::isIn((*a)[i], b))
@@ -330,8 +330,8 @@ public:
 
 
 
-     static std::set<_T>* symmetricDifference(vector<_T>* a, vector<_T>* b)
-    { std::set<_T>* res = new std::set<_T>();
+     static set<_T>* symmetricDifference(vector<_T>* a, vector<_T>* b)
+    { set<_T>* res = new set<_T>();
       for (int i = 0; i < a->size(); i++)
       { if (UmlRsdsLib<_T>::isIn((*a)[i], b)) { }
         else { res->insert((*a)[i]); }
@@ -343,9 +343,9 @@ public:
       return res;
     }
 
-    static std::set<_T>* symmetricDifference(std::set<_T>* a, vector<_T>* b)
-    { std::set<_T>* res = new std::set<_T>();
-      for (std::set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
+    static set<_T>* symmetricDifference(set<_T>* a, vector<_T>* b)
+    { set<_T>* res = new set<_T>();
+      for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, b)) { }
         else { res->insert(*_pos); }
       }
@@ -356,26 +356,26 @@ public:
       return res;
     }
 
-     static std::set<_T>* symmetricDifference(vector<_T>* a, std::set<_T>* b)
-    { std::set<_T>* res = new std::set<_T>();
+     static set<_T>* symmetricDifference(vector<_T>* a, set<_T>* b)
+    { set<_T>* res = new set<_T>();
       for (int i = 0; i < a->size(); i++)
       { if (UmlRsdsLib<_T>::isIn((*a)[i], b)) { }
         else { res->insert((*a)[i]); }
       }
-      for (std::set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
+      for (set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, a)) { }
         else { res->insert(*_pos); }
       }
       return res;
     }
 
-    static std::set<_T>* symmetricDifference(std::set<_T>* a, std::set<_T>* b)
-    { std::set<_T>* res = new std::set<_T>();
-      for (std::set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
+    static set<_T>* symmetricDifference(set<_T>* a, set<_T>* b)
+    { set<_T>* res = new set<_T>();
+      for (set<_T>::iterator _pos = a->begin(); _pos != a->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, b)) { }
         else { res->insert(*_pos); }
       }
-      for (std::set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
+      for (set<_T>::iterator _pos = b->begin(); _pos != b->end(); _pos++)
       { if (UmlRsdsLib<_T>::isIn(*_pos, a)) { }
         else { res->insert(*_pos); }
       }
@@ -385,7 +385,7 @@ public:
 
 
   static bool isUnique(vector<_T>* evals)
-  { std::set<_T> vals; 
+  { set<_T> vals; 
     for (int i = 0; i < evals->size(); i++)
     { _T ob = (*evals)[i]; 
       if (vals.find(ob) != vals.end()) { return false; }
@@ -393,7 +393,7 @@ public:
     }
     return true;
   }
-  static bool isUnique(std::set<_T>* evals)
+  static bool isUnique(set<_T>* evals)
   { return true; }
 
 
@@ -434,9 +434,9 @@ public:
     { _sum.append( (*a)[i] ); }
     return _sum; }
 
-  static string sumString(std::set<string>* a)
+  static string sumString(set<string>* a)
   { string _sum(""); 
-    std::set<string>::iterator _pos;
+    set<string>::iterator _pos;
     for (_pos = a->begin(); _pos != a->end(); ++_pos)
     { _sum.append( *_pos ); }
     return _sum; }
@@ -447,9 +447,9 @@ public:
     { _sum += (*a)[i]; }
     return _sum; }
 
-  static _T sum(std::set<_T>* a)
+  static _T sum(set<_T>* a)
   { _T _sum(0); 
-    std::set<_T>::iterator _pos;
+    set<_T>::iterator _pos;
     for (_pos = a->begin(); _pos != a->end(); ++_pos)
     { _sum += *_pos; }
     return _sum; }
@@ -462,9 +462,9 @@ public:
     { _prd *= (*a)[i]; }
     return _prd; }
 
-  static _T prd(std::set<_T>* a)
+  static _T prd(set<_T>* a)
   { _T _prd(1); 
-    std::set<_T>::iterator _pos;
+    set<_T>::iterator _pos;
     for (_pos = a->begin(); _pos != a->end(); ++_pos)
     { _prd *= *_pos; }
     return _prd; }
@@ -478,7 +478,7 @@ public:
     return res;
   }
 
-  static vector<_T>* concatenate(vector<_T>* a, std::set<_T>* b)
+  static vector<_T>* concatenate(vector<_T>* a, set<_T>* b)
   { vector<_T>* res = new vector<_T>(); 
     res->insert(res->end(), a->begin(),a->end()); 
     res->insert(res->end(), b->begin(),b->end()); 
@@ -488,13 +488,13 @@ public:
 
 
 
-     static std::set<_T>* asSet(vector<_T>* c)
-    { std::set<_T>* res = new std::set<_T>();
+     static set<_T>* asSet(vector<_T>* c)
+    { set<_T>* res = new set<_T>();
       res->insert(c->begin(), c->end());
       return res;
     }
 
-    static std::set<_T>* asSet(std::set<_T>* c)
+    static set<_T>* asSet(set<_T>* c)
     { return c; }
 
     static vector<_T>* asOrderedSet(vector<_T>* c)
@@ -518,7 +518,7 @@ public:
     { vector<_T>* res = new vector<_T>();
       for (vector<_T>::iterator _pos = sq->begin(); _pos != sq->end(); ++_pos)
       { res->push_back(*_pos); }
-      std::random_shuffle(res->begin(), res->end());
+      random_shuffle(res->begin(), res->end());
       return res; 
     }
 
@@ -527,7 +527,7 @@ public:
   static vector<_T>* reverse(vector<_T>* a)
   { vector<_T>* res = new vector<_T>(); 
     res->insert(res->end(), a->begin(), a->end()); 
-    std::reverse(res->begin(), res->end()); 
+    reverse(res->begin(), res->end()); 
     return res; }
 
   static string reverse(string a)
@@ -559,14 +559,14 @@ public:
   static vector<_T>* sort(vector<_T>* a)
   { vector<_T>* res = new vector<_T>();
     res->insert(res->end(), a->begin(), a->end());
-    std::sort(res->begin(), res->end());
+    sort(res->begin(), res->end());
     return res;
   }
 
-  static vector<_T>* sort(std::set<_T>* a)
+  static vector<_T>* sort(set<_T>* a)
   { vector<_T>* res = new vector<_T>();
     res->insert(res->end(), a->begin(), a->end());
-    std::sort(res->begin(), res->end());
+    sort(res->begin(), res->end());
     return res;
   }
 
@@ -610,12 +610,12 @@ public:
   }
 
 
-  static int count(std::set<_T>* l, _T obj)
+  static int count(set<_T>* l, _T obj)
   { if (l->find(obj) != l->end()) { return 1; } else { return 0; } 
   }
 
   static int count(vector<_T>* l, _T obj)
-  { return std::count(l->begin(), l->end(), obj); }
+  { return count(l->begin(), l->end(), obj); }
 
   static int count(string s, string x)
   { int res = 0; 
@@ -649,9 +649,9 @@ public:
       return v->at(0);
     }
 
-  static _T any(std::set<_T>* v)
+  static _T any(set<_T>* v)
     { if (v->size() == 0) { return 0; }
-      std::set<_T>::iterator _pos = v->begin();
+      set<_T>::iterator _pos = v->begin();
       return *_pos;
     }
 
@@ -662,9 +662,9 @@ public:
       return v->at(0);
     }
 
-  static _T first(std::set<_T>* v)
+  static _T first(set<_T>* v)
     { if (v->size() == 0) { return 0; }
-      std::set<_T>::iterator _pos = v->begin();
+      set<_T>::iterator _pos = v->begin();
       return *_pos;
     }
 
@@ -675,9 +675,9 @@ public:
     return v->at(v->size() - 1);
   }
 
-  static _T last(std::set<_T>* v)
+  static _T last(set<_T>* v)
   { if (v->size() == 0) { return 0; }
-    std::set<_T>::iterator _pos = v->end();
+    set<_T>::iterator _pos = v->end();
     _pos--;
     return *_pos;
   }
@@ -838,11 +838,11 @@ public:
   }
 
 
-  static std::set<_T>* intersectAll(std::set<std::set<_T>*>* se)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* intersectAll(set<set<_T>*>* se)
+  { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    std::set<set<_T>*>::iterator _pos = se->begin();
-    std::set<_T>* frst = *_pos;
+    set<set<_T>*>::iterator _pos = se->begin();
+    set<_T>* frst = *_pos;
     res->insert(frst->begin(), frst->end());
     ++_pos; 
     for (; _pos != se->end(); ++_pos)
@@ -850,10 +850,10 @@ public:
     return res;
   }
 
-  static std::set<_T>* intersectAll(std::set<vector<_T>*>* se)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* intersectAll(set<vector<_T>*>* se)
+  { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    std::set<vector<_T>*>::iterator _pos = se->begin();
+    set<vector<_T>*>::iterator _pos = se->begin();
     vector<_T>* frst = *_pos;
     res->insert(frst->begin(), frst->end());
     ++_pos; 
@@ -862,10 +862,10 @@ public:
     return res;
   }
 
-  static std::set<_T>* intersectAll(vector<std::set<_T>*>* se)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* intersectAll(vector<set<_T>*>* se)
+  { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    std::set<_T>* frst = (*se)[0];
+    set<_T>* frst = (*se)[0];
     res->insert(frst->begin(), frst->end());
     for (int i = 1; i < se->size(); ++i)
     { res = UmlRsdsLib<_T>::intersection(res, (*se)[i]); }
@@ -884,26 +884,26 @@ public:
 
 
 
-  static std::set<_T>* unionAll(std::set<set<_T>*>* se)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* unionAll(set<set<_T>*>* se)
+  { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    std::set<set<_T>*>::iterator _pos;
+    set<set<_T>*>::iterator _pos;
     for (_pos = se->begin(); _pos != se->end(); ++_pos)
     { res = UmlRsdsLib<_T>::unionSet(res, *_pos); }
     return res;
   }
 
-  static std::set<_T>* unionAll(std::set<vector<_T>*>* se)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* unionAll(set<vector<_T>*>* se)
+  { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
-    std::set<vector<_T>*>::iterator _pos;
+    set<vector<_T>*>::iterator _pos;
     for (_pos = se->begin(); _pos != se->end(); ++_pos)
     { res = UmlRsdsLib<_T>::unionSet(res, *_pos); }
     return res;
   }
 
-  static std::set<_T>* unionAll(vector<set<_T>*>* se)
-  { std::set<_T>* res = new std::set<_T>(); 
+  static set<_T>* unionAll(vector<set<_T>*>* se)
+  { set<_T>* res = new set<_T>(); 
     if (se->size() == 0) { return res; }
     for (int i = 0; i < se->size(); ++i)
     { res = UmlRsdsLib<_T>::unionSet(res, (*se)[i]); }
@@ -1089,13 +1089,13 @@ public:
 
 
  static bool isInteger(string str)
-  { try { std::stoi(str); return true; }
+  { try { stoi(str); return true; }
     catch (exception _e) { return false; }
   }
 
 
  static bool isReal(string str)
-  { try { std::stod(str); return true; }
+  { try { stod(str); return true; }
     catch (exception _e) { return false; }
   }
 
@@ -1111,19 +1111,19 @@ public:
 
     if (str[0] == '0' && str.length() > 1 && str[1] == 'x')
     { try {
-        int x = std::stoi(str, 0, 16);
+        int x = stoi(str, 0, 16);
         return x; 
       }
       catch (exception e) { return 0; }
     }
     else if (str[0] == '0' && str.length() > 1)
     { try { 
-        int y = std::stoi(str, 0, 8);
+        int y = stoi(str, 0, 8);
         return y;
       } catch (exception f)
         { return 0; }
     }  
-    try { int z = std::stoi(str, 0, 10);
+    try { int z = stoi(str, 0, 10);
           return z;
     } 
     catch (exception g) { return 0; } 
@@ -1136,19 +1136,19 @@ public:
 
     if (str[0] == '0' && str.length() > 1 && str[1] == 'x')
     { try {
-        long x = std::stol(str, 0, 16);
+        long x = stol(str, 0, 16);
         return x; 
       }
       catch (exception e) { return 0; }
     }
     else if (str[0] == '0' && str.length() > 1)
     { try { 
-        long y = std::stol(str, 0, 8);
+        long y = stol(str, 0, 8);
         return y;
       } catch (exception f)
         { return 0; }
     }  
-    try { long z = std::stol(str, 0, 10);
+    try { long z = stol(str, 0, 10);
           return z;
     } 
     catch (exception g) { return 0; } 
@@ -1160,7 +1160,7 @@ public:
     { return 0.0; }
 
     try {
-      double x = std::stod(str);
+      double x = stod(str);
       return x; 
     }
     catch (exception e) { return 0.0; }
@@ -1169,21 +1169,21 @@ public:
 
 
  static bool isLong(string str)
-  { try { std::stol(str); return true; }
+  { try { stol(str); return true; }
     catch (exception _e) { return false; }
   }
 
 
   static bool hasMatch(string str, string patt)
-  { std::regex rr(patt);
-    return std::regex_search(str,rr);
+  { regex rr(patt);
+    return regex_search(str,rr);
   }
 
 
 
   static bool isMatch(string str, string patt)
-  { std::regex rr(patt);
-    return std::regex_match(str,rr);
+  { regex rr(patt);
+    return regex_match(str,rr);
   }
 
 
@@ -1193,13 +1193,13 @@ public:
     vector<string>* res = new vector<string>(); 
     if (slen == 0)  
     { return res; }  
-    std::regex patt_regex(patt);
-    auto words_begin = std::sregex_iterator(s.begin(), s.end(), patt_regex);
-    auto words_end = std::sregex_iterator();
+    regex patt_regex(patt);
+    auto words_begin = sregex_iterator(s.begin(), s.end(), patt_regex);
+    auto words_end = sregex_iterator();
     
-    for (std::sregex_iterator i = words_begin; i != words_end; ++i)
-    { std::smatch match = *i;
-      std::string match_str = match.str();
+    for (sregex_iterator i = words_begin; i != words_end; ++i)
+    { smatch match = *i;
+      string match_str = match.str();
       if (match_str.length() > 0)
       { res->push_back(match_str); }
     }
@@ -1212,13 +1212,13 @@ public:
     string res = ""; 
     if (slen == 0)  
     { return res; }  
-    std::regex patt_regex(patt);
-    auto words_begin = std::sregex_iterator(s.begin(), s.end(), patt_regex);
-    auto words_end = std::sregex_iterator();
+    regex patt_regex(patt);
+    auto words_begin = sregex_iterator(s.begin(), s.end(), patt_regex);
+    auto words_end = sregex_iterator();
     
-    for (std::sregex_iterator i = words_begin; i != words_end; ++i)
-    { std::smatch match = *i;
-      std::string match_str = match.str();
+    for (sregex_iterator i = words_begin; i != words_end; ++i)
+    { smatch match = *i;
+      string match_str = match.str();
       if (match_str.length() > 0)
       { return match_str; }
     }
@@ -1227,17 +1227,17 @@ public:
 
 
   static string replaceAll(string text, string patt, string rep)
-  { std::regex patt_re(patt);
-    std::string res = std::regex_replace(text, patt_re, rep);
+  { regex patt_re(patt);
+    string res = regex_replace(text, patt_re, rep);
     return res;
   }
 
 
   static string replaceFirstMatch(string text, string patt, string rep)
-  { std::regex patt_re(patt);
-    std::regex_constants::match_flag_type fonly =
-           std::regex_constants::format_first_only;
-    std::string res = std::regex_replace(text, patt_re, rep, fonly);
+  { regex patt_re(patt);
+    regex_constants::match_flag_type fonly =
+           regex_constants::format_first_only;
+    string res = regex_replace(text, patt_re, rep, fonly);
     return res;
   }
 
@@ -1249,12 +1249,12 @@ public:
     { res->push_back(s);
       return res; 
     } 
-    std::regex patt_regex(patt);
-    auto words_begin = std::sregex_iterator(s.begin(), s.end(), patt_regex);
-    auto words_end = std::sregex_iterator();
+    regex patt_regex(patt);
+    auto words_begin = sregex_iterator(s.begin(), s.end(), patt_regex);
+    auto words_end = sregex_iterator();
     int prev = 0; 
-    for (std::sregex_iterator i = words_begin; i != words_end; ++i)
-    { std::smatch match = *i;
+    for (sregex_iterator i = words_begin; i != words_end; ++i)
+    { smatch match = *i;
       int pos = match.position(0);
       int ln = match.length(0); 
       if (ln > 0)
@@ -1462,9 +1462,9 @@ public:
   } 
 
 
-  static std::set<string>* keys(map<string,_T>* s)
+  static set<string>* keys(map<string,_T>* s)
   { map<string,_T>::iterator iter;
-    std::set<string>* res = new std::set<string>();
+    set<string>* res = new set<string>();
   
     for (iter = s->begin(); iter != s->end(); ++iter)
     { string key = iter->first;
@@ -1486,7 +1486,7 @@ public:
   }
 
 
-  static map<string,_T>* restrict(map<string,_T>* m1, std::set<string>* ks)
+  static map<string,_T>* restrict(map<string,_T>* m1, set<string>* ks)
   { map<string,_T>* res = new map<string,_T>();
     map<string,_T>::iterator iter;
     for (iter = m1->begin(); iter != m1->end(); ++iter)
@@ -1497,7 +1497,7 @@ public:
     return res;
   }
 
-  static map<string,_T>* antirestrict(map<string,_T>* m1, std::set<string>* ks)
+  static map<string,_T>* antirestrict(map<string,_T>* m1, set<string>* ks)
   { map<string,_T>* res = new map<string,_T>();
     map<string,_T>::iterator iter;
     for (iter = m1->begin(); iter != m1->end(); ++iter)

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -1849,16 +1849,3 @@ public:
    private: 
      const char* message;
   };
-
-
-   
-};
-
-
-
-
-
-
-
-
-

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -1744,7 +1744,7 @@ public:
         return ex; 
       }
 
-      const char* what() const { return message; }
+      const char* what() const noexcept { return message; }
 
       string getMessage() { return string(message); }
 
@@ -1773,7 +1773,7 @@ public:
         return ex; 
       }
 
-      const char* what() const { return message; }
+      const char* what() const noexcept { return message; }
 
       string getMessage() { return string(message); }
 
@@ -1802,7 +1802,7 @@ public:
         return ex; 
       }
 
-      const char* what() const { return message; }
+      const char* what() const noexcept { return message; }
 
       string getMessage() { return string(message); }
 
@@ -1831,7 +1831,7 @@ public:
         return ex; 
       }
 
-      const char* what() const { return message; }
+      const char* what() const noexcept { return message; }
 
       string getMessage() { return string(message); }
 

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <ctime>
+#include <cmath>
 
 using namespace std;
 

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <ctime>
 #include <cmath>
+#include <iostream>
 #include <iosfwd>
 
 using namespace std;

--- a/libraries/OCLC++11.h
+++ b/libraries/OCLC++11.h
@@ -3,6 +3,9 @@
 #undef max
 #undef min
 
+#include <set>
+#include <vector>
+
 using namespace std;
 
 class Runnable


### PR DESCRIPTION
The errors in OCLC++11.h still need to be fixed, but I'm opening this PR so that the syntax-error-free OCLC++.h can still be merged. A separate PR will be opened on this branch once OCLC++11.h is free from syntax errors. I may push further changes to OCLC+11.h to this branch while this PR is still open, but I would still like for this PR to get merged anyway, since I still plan to open a separate OCLC++11.h PR (as aforementioned).